### PR TITLE
Fix: scan_list bugs

### DIFF
--- a/src/cpp/include/list_scanning.h
+++ b/src/cpp/include/list_scanning.h
@@ -378,9 +378,12 @@ inline void scan_list(const float *query_vec,
                      faiss::MetricType metric = faiss::METRIC_L2) {
 
     #ifdef QUAKE_ENABLE_GPU
+        if (list_size <= 0) {
+            return;
+        }
         cudaError_t cuda_status;
         // Call the GPU implementation
-        int k = buffer.k_; 
+        int k = std::min(list_size, buffer.k_); 
 
         // Allocate host memory for input data transfer if needed
         float* h_query = nullptr;


### PR DESCRIPTION
This pull request introduces a safeguard to the `scan_list` function in `list_scanning.h` to handle edge cases where the list size is non-positive, ensuring the function exits early without performing unnecessary operations.

Key changes:

### Edge case handling:
* Added a condition to check if `list_size` is less than or equal to zero. If true, the function returns immediately, preventing further execution.